### PR TITLE
Updates speedtest-cli to fix "SSL Config" crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,7 @@ WORKDIR /app
 COPY src/. .
 
 RUN adduser -D speedtest
-RUN pip install -r requirements.txt && \
-    export ARCHITECTURE=$(uname -m) && \
-    if [ "$ARCHITECTURE" == 'armv7l' ]; then export ARCHITECTURE=arm; fi && \
-    wget -O /tmp/speedtest.tgz "https://bintray.com/ookla/download/download_file?file_path=ookla-speedtest-1.0.0-${ARCHITECTURE}-linux.tgz" && \
-    tar zxvf /tmp/speedtest.tgz -C /tmp && \
-    cp /tmp/speedtest /usr/local/bin && \
-    rm requirements.txt
+RUN pip install -r requirements.txt && rm requirements.txt
 
 RUN chown -R speedtest:speedtest /app
 

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -37,33 +37,6 @@ def is_json(myjson):
         return False
     return True
 
-
-def runTest():
-    serverID = os.environ.get('SPEEDTEST_SERVER')
-    cmd = ["speedtest", "--json"]
-    if serverID:
-        cmd.append(f"--server {serverID}")
-    output = subprocess.check_output(cmd)
-    if is_json(output):
-        data = json.loads(output)
-        if "error" in data:
-            # Socket error
-            print('Something went wrong')
-            print(data['error'])
-            return (0, 0, 0, 0, 0, 0)  # Return all data as 0
-        if "type" in data:
-            if data['type'] == 'log':
-                print(str(data["timestamp"]) + " - " + str(data["message"]))
-            if data['type'] == 'result':
-                actual_server = int(data['server']['id'])
-                actual_jitter = data['ping']['jitter']
-                actual_ping = data['ping']['latency']
-                download = bytes_to_bits(data['download']['bandwidth'])
-                upload = bytes_to_bits(data['upload']['bandwidth'])
-                return (actual_server, actual_jitter,
-                        actual_ping, download, upload, 1)
-
-
 @app.route("/metrics")
 def updateResults():
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,3 +2,4 @@ Werkzeug==1.0.1
 Flask==1.1.2
 prometheus_client==0.10.1
 waitress==2.0.0
+speedtest-cli==2.1.3


### PR DESCRIPTION
Updates to speedtest-cli v2.1.3

Input arguments and JSON output structure changed. Jitter is no longer returned, but didn't seem to be used in the dashboard anyway.

Could use some cleanup as I'm not a Python programmer.