### PR TITLE
add ability to configure a timeout for the speedtest process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN adduser -D speedtest
 RUN pip install -r requirements.txt && \
     export ARCHITECTURE=$(uname -m) && \
     if [ "$ARCHITECTURE" == 'armv7l' ]; then export ARCHITECTURE=arm; fi && \
-    wget -O /tmp/speedtest.tgz "https://bintray.com/ookla/download/download_file?file_path=ookla-speedtest-1.0.0-${ARCHITECTURE}-linux.tgz" && \
+    wget -O /tmp/speedtest.tgz "https://install.speedtest.net/app/cli/ookla-speedtest-1.0.0-${ARCHITECTURE}-linux.tgz" && \
     tar zxvf /tmp/speedtest.tgz -C /tmp && \
     cp /tmp/speedtest /usr/local/bin && \
     rm requirements.txt

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -40,12 +40,21 @@ def is_json(myjson):
 
 def runTest():
     serverID = os.environ.get('SPEEDTEST_SERVER')
+
+    # Defaults to None if not set
+    process_timeout = os.environ.get('SPEEDTEST_TIMEOUT')
+
+    try:
+        process_timeout = int(process_timeout)
+    except Exception:
+        process_timeout = None
+
     cmd = ["speedtest", "--format=json-pretty", "--progress=no",
            "--accept-license", "--accept-gdpr"]
     if serverID:
         cmd.append(f"--server-id={serverID}")
     try:
-        output = subprocess.check_output(cmd)
+        output = subprocess.check_output(cmd, timeout=process_timeout)
     except subprocess.CalledProcessError as e:
         output = e.output
         if not is_json(output):
@@ -54,6 +63,11 @@ def runTest():
                       'was not in JSON format')
                 print(output)
             return (0, 0, 0, 0, 0, 0)
+    except subprocess.TimeoutExpired:
+        print('Speedtest CLI process took too long to complete ' +
+              'and was killed.')
+        return (0, 0, 0, 0, 0, 0)
+
     if is_json(output):
         data = json.loads(output)
         if "error" in data:


### PR DESCRIPTION
This adds the ability to optionally configure a timeout for the speedtest process.

It can be set using the `SPEEDTEST_TIMEOUT` environment variable.
If the timeout occurs then a log-message will be generated and a zero result is returned.
```
Speedtest CLI process took too long to complete and was killed.
20/07/2021 05:55:11 - Server: 0 | Jitter: 0 ms | Ping: 0 ms | Download: 0.0 Mb/s | Upload:0.0 Mb/s
```

If the `SPEEDTEST_TIMEOUT` variable is NOT set then the existing behaviour is maintained (i.e. the process can run forever)

I also needed to update the URL where the speedtest tarball is downloaded from as the bintray link appears to not work anymore.

This fixes #83 