### PR TITLE
Make dependabot update GH Actions too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Thanks for this project.

I noted in a recent release that you have been manually managing the GitHub Actions, and wanted to contribute this change which may help make things easier.

Thanks again for this great project!