### PR TITLE
Feat add cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG SPEEDTEST_VERSION=1.1.1
 RUN adduser -D speedtest
 
 WORKDIR /app
-COPY src/. .
+COPY src/requirements.txt .
 
 # Install required modules and Speedtest CLI
 RUN pip install --no-cache-dir -r requirements.txt && \
@@ -21,6 +21,8 @@ RUN pip install --no-cache-dir -r requirements.txt && \
     rm -rf \
      /tmp/* \
      /app/requirements
+
+COPY src/. .
 
 USER speedtest
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,3 +2,4 @@ Werkzeug==2.0.2
 Flask==2.0.2
 prometheus_client==0.12.0
 waitress==2.0.0
+datetime==4.2


### PR DESCRIPTION
Cache result: add an option to cache speedtest results for N seconds, prometheus/grafana don't like to have a big scrape interval (> 5 min) and I don't want to speedtest every time.

Optimize Dockerfile: since both `requirements.txt` and speedtest-cli tend to not change much we first install them on a separate layer to improve build time and save bandwidth