### PR TITLE
Add ARMv6 support for RasPi (Zero) devices

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
           push: true
           tags: | 
             miguelndecarvalho/speedtest-exporter:latest


### PR DESCRIPTION
Hi there!

Thanks again for this project.

I'd like to run this exporter on a Pi Zero, which is ARMv6.

This corrects the error observed when running the current image:
```
WARNING: The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/arm/v6) and no specific platform was requested
```

Thanks again for the great project!