### PR TITLE
RFC: Rewrite with custom collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ COPY src/. .
 
 USER speedtest
 
-CMD ["python", "-u", "exporter.py"]
+CMD ["python", "-u", "main.py"]
 
 HEALTHCHECK --timeout=10s CMD wget --no-verbose --tries=1 --spider http://localhost:${SPEEDTEST_PORT:=9798}/

--- a/src/cache.py
+++ b/src/cache.py
@@ -1,0 +1,61 @@
+#
+
+import dataclasses
+import functools
+import time
+
+
+def ttl_cache(ttl=60, typed=False):
+    make_key = functools._make_key
+
+    @dataclasses.dataclass
+    class Cache:
+        expiration: float
+        value: object
+
+    def decorator(func):
+        func.cache = {}
+
+        def clear():
+            func.cache.clear()
+
+        def get(*args, default=None, **kwargs):
+            sentinel = object()
+            key = make_key(args, kwargs, typed=typed)
+
+            cache = func.cache.get(key, sentinel)
+
+            if cache is sentinel:
+                return default
+
+            if cache.expiration < time.monotonic():
+                del func.cache[key]
+                return default
+
+            return cache
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            sentinel = object()
+            cached = get(*args, default=sentinel, **kwargs)
+
+            if cached is sentinel:
+                # NOTE(jkoelker) Run the func prior to expiration calculation.
+                value = func(*args, **kwargs)
+
+                cached = Cache(
+                    expiration=time.monotonic() + ttl,
+                    value=value,
+                )
+
+                key = make_key(args, kwargs, typed=typed)
+                func.cache[key] = cached
+
+            return cached.value
+
+        wrapper.get = get
+        wrapper.clear = clear
+
+        return wrapper
+
+    return decorator

--- a/src/data.py
+++ b/src/data.py
@@ -1,0 +1,147 @@
+#
+
+import dataclasses
+import datetime
+
+
+@dataclasses.dataclass
+class Interface:
+    external_ip: str
+    internal_ip: str
+    is_vpn: bool
+    mac_address: str
+    name: str
+
+    @classmethod
+    def parse(cls, payload: dict) -> 'Interface':
+        return cls(
+            external_ip=payload.get('external_ip', ''),
+            internal_ip=payload.get('internal_ip', ''),
+            is_vpn=payload.get('is_vpn', False),
+            mac_address=payload.get('mac_address', ''),
+            name=payload.get('name', ''),
+        )
+
+
+@dataclasses.dataclass
+class Latency:
+    igm: float
+    low: float
+    high: float
+    jitter: float
+
+    @classmethod
+    def parse(cls, payload: dict) -> 'Latency':
+        return cls(
+            igm=payload.get('igm', 0),
+            low=payload.get('low', 0),
+            high=payload.get('high', 0),
+            jitter=payload.get('jitter', 0),
+        )
+
+
+@dataclasses.dataclass
+class Ping:
+    jitter: float
+    latency: float
+    low: float
+    high: float
+
+    @classmethod
+    def parse(cls, payload: dict) -> 'Ping':
+        return cls(
+            jitter=payload.get('jitter', 0),
+            latency=payload.get('latency', 0),
+            low=payload.get('low', 0),
+            high=payload.get('high', 0),
+        )
+
+
+@dataclasses.dataclass
+class Result:
+    id: str
+    persisted: bool
+    url: str
+
+    @classmethod
+    def parse(cls, payload: dict) -> 'Result':
+        return cls(
+            id=payload.get('id', ''),
+            persisted=payload.get('persisted', False),
+            url=payload.get('url', ''),
+        )
+
+
+@dataclasses.dataclass
+class Speedtest:
+    bandwidth: int
+    bytes: int
+    elapsed: int
+    latency: float
+
+    @classmethod
+    def parse(cls, payload: dict) -> 'Speedtest':
+        return cls(
+            bandwidth=payload.get('bandwidth', 0),
+            bytes=payload.get('bytes', 0),
+            elapsed=payload.get('elapsed', 0),
+            latency=payload.get('latency', 0),
+        )
+
+    def bps(self) -> int:
+        return self.bandwidth * 8
+
+
+@dataclasses.dataclass
+class Server:
+    id: int
+    host: str
+    port: int
+    name: str
+    location: str
+    country: str
+    ip: str
+
+    @classmethod
+    def parse(cls, payload: dict) -> 'Server':
+        return cls(
+            id=payload.get('id', 0),
+            host=payload.get('host', ''),
+            port=payload.get('port', 0),
+            name=payload.get('name', ''),
+            location=payload.get('location', ''),
+            country=payload.get('country', ''),
+            ip=payload.get('ip', ''),
+        )
+
+
+@dataclasses.dataclass
+class SpeedtestResult:
+    download: Speedtest
+    interface: Interface
+    isp: str
+    packet_loss: float
+    ping: Ping
+    result: Result
+    server: Server
+    timestamp: datetime.datetime
+    type: str
+    upload: Speedtest
+
+    @classmethod
+    def parse(cls, payload: dict) -> 'SpeedtestResult':
+        return cls(
+            download=Speedtest.parse(payload.get('download', {})),
+            interface=Interface.parse(payload.get('interface', {})),
+            isp=payload.get('isp', ''),
+            packet_loss=payload.get('packetLoss', 0),
+            ping=Ping.parse(payload.get('ping', {})),
+            result=Result.parse(payload.get('result', {})),
+            server=Server.parse(payload.get('server', {})),
+            timestamp=datetime.datetime.strptime(
+                payload.get('timestamp', '1970-01-01T00:00:00Z'),
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+            type=payload.get('type', ''),
+            upload=Speedtest.parse(payload.get('upload', {})),
+        )

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -1,153 +1,143 @@
 #!python
 
-import datetime
 import logging
 import json
-import os
-import shutil
 import subprocess
+import typing
 
-from flask import Flask
-from prometheus_client import make_wsgi_app, Gauge
-from waitress import serve
+import prometheus_client as prometheus
 
-app = Flask("Speedtest-Exporter")  # Create flask app
-
-# Setup logging values
-format_string = 'level=%(levelname)s datetime=%(asctime)s %(message)s'
-logging.basicConfig(encoding='utf-8',
-                    level=logging.DEBUG,
-                    format=format_string)
-
-# Disable Waitress Logs
-log = logging.getLogger('waitress')
-log.disabled = True
-
-# Create Metrics
-server = Gauge('speedtest_server_id', 'Speedtest server ID used to test')
-jitter = Gauge('speedtest_jitter_latency_milliseconds',
-               'Speedtest current Jitter in ms')
-ping = Gauge('speedtest_ping_latency_milliseconds',
-             'Speedtest current Ping in ms')
-download_speed = Gauge('speedtest_download_bits_per_second',
-                       'Speedtest current Download Speed in bit/s')
-upload_speed = Gauge('speedtest_upload_bits_per_second',
-                     'Speedtest current Upload speed in bits/s')
-up = Gauge('speedtest_up', 'Speedtest status whether the scrape worked')
-
-# Cache metrics for how long (seconds)?
-cache_seconds = int(os.environ.get('SPEEDTEST_CACHE_FOR', 0))
-cache_until = datetime.datetime.fromtimestamp(0)
+import cache
+import data
+import metrics
 
 
-def bytes_to_bits(bytes_per_sec):
-    return bytes_per_sec * 8
-
-
-def bits_to_megabits(bits_per_sec):
-    megabits = round(bits_per_sec * (10**-6), 2)
-    return str(megabits) + "Mbps"
-
-
-def is_json(myjson):
+def safe_json(payload) -> typing.Optional[dict]:
     try:
-        json.loads(myjson)
+        return json.loads(payload)
     except ValueError:
-        return False
-    return True
+        return None
+
+    return None
 
 
-def runTest():
-    serverID = os.environ.get('SPEEDTEST_SERVER')
-    timeout = int(os.environ.get('SPEEDTEST_TIMEOUT', 90))
-
+def speedtest(
+    server_id: str = '',
+    timeout: int = 90,
+) -> typing.Optional[data.SpeedtestResult]:
     cmd = [
-        "speedtest", "--format=json-pretty", "--progress=no",
-        "--accept-license", "--accept-gdpr"
+        "speedtest",
+        "--format=json",
+        "--progress=no",
+        "--accept-license",
+        "--accept-gdpr",
     ]
-    if serverID:
-        cmd.append(f"--server-id={serverID}")
+
+    if server_id:
+        cmd.append(f"--server-id={server_id}")
+
     try:
         output = subprocess.check_output(cmd, timeout=timeout)
+
     except subprocess.CalledProcessError as e:
         output = e.output
-        if not is_json(output):
-            if len(output) > 0:
-                logging.error('Speedtest CLI Error occurred that' +
-                              'was not in JSON format')
-            return (0, 0, 0, 0, 0, 0)
     except subprocess.TimeoutExpired:
         logging.error('Speedtest CLI process took too long to complete ' +
                       'and was killed.')
-        return (0, 0, 0, 0, 0, 0)
+        return None
 
-    if is_json(output):
-        data = json.loads(output)
-        if "error" in data:
-            # Socket error
-            print('Something went wrong')
-            print(data['error'])
-            return (0, 0, 0, 0, 0, 0)  # Return all data as 0
-        if "type" in data:
-            if data['type'] == 'log':
-                print(str(data["timestamp"]) + " - " + str(data["message"]))
-            if data['type'] == 'result':
-                actual_server = int(data['server']['id'])
-                actual_jitter = data['ping']['jitter']
-                actual_ping = data['ping']['latency']
-                download = bytes_to_bits(data['download']['bandwidth'])
-                upload = bytes_to_bits(data['upload']['bandwidth'])
-                return (actual_server, actual_jitter, actual_ping, download,
-                        upload, 1)
+    result = safe_json(output)
 
+    if not result:
+        if len(output) > 0:
+            logging.error('Speedtest CLI Error occurred that' +
+                          'was not in JSON format')
+        return None
 
-@app.route("/metrics")
-def updateResults():
-    global cache_until
+    error = result.get('error')
+    if error:
+        # Socket error
+        print(f'Something went wrong: {error}')
+        return None
 
-    if datetime.datetime.now() > cache_until:
-        r_server, r_jitter, r_ping, r_download, r_upload, r_status = runTest()
-        server.set(r_server)
-        jitter.set(r_jitter)
-        ping.set(r_ping)
-        download_speed.set(r_download)
-        upload_speed.set(r_upload)
-        up.set(r_status)
-        logging.info("Server=" + str(r_server) + " Jitter=" + str(r_jitter) +
-                     "ms" + " Ping=" + str(r_ping) + "ms" + " Download=" +
-                     bits_to_megabits(r_download) + " Upload=" +
-                     bits_to_megabits(r_upload))
+    result_type = result.get('type')
 
-        cache_until = datetime.datetime.now() + datetime.timedelta(
-            seconds=cache_seconds)
+    if result_type == 'log':
+        timestamp = result.get('timestamp')
+        message = result.get('message')
 
-    return make_wsgi_app()
+        print(str(timestamp) + " - " + str(message))
+
+        return None
+
+    if result_type == 'result':
+        return data.SpeedtestResult.parse(result)
+
+    return None
 
 
-@app.route("/")
-def mainPage():
-    return ("<h1>Welcome to Speedtest-Exporter.</h1>" +
-            "Click <a href='/metrics'>here</a> to see metrics.")
+class SpeedtestExporter:
+    def __init__(
+        self,
+        cache_seconds: int = 0,
+        server_id: str = '',
+        timeout: int = 90,
+    ):
+        self._cache_seconds = cache_seconds
+        self._server_id = server_id
+        self._timeout = timeout
 
+        self._speedtest = cache.ttl_cache(ttl=cache_seconds)(speedtest)
+        self._speedtest = self.duration.time()(self._speedtest)
 
-def checkForBinary():
-    if shutil.which("speedtest") is None:
-        logging.error("Speedtest CLI binary not found. Please install it by" +
-                      " going to the official website.\n" +
-                      "https://www.speedtest.net/apps/cli")
-        exit(1)
-    speedtestVersionDialog = (subprocess.run(['speedtest', '--version'],
-                              capture_output=True, text=True))
-    if "Speedtest by Ookla" not in speedtestVersionDialog.stdout:
-        logging.error("Speedtest CLI that is installed is not the official" +
-                      " one. Please install it by going to the official" +
-                      " website.\nhttps://www.speedtest.net/apps/cli")
-        exit(1)
+    duration = prometheus.Summary(
+        'speedtest_duration_seconds',
+        'duration in seconds',
+    )
 
+    def clear(self):
+        self._speedtest.clear()
 
-if __name__ == '__main__':
-    checkForBinary()
-    PORT = os.getenv('SPEEDTEST_PORT', 9798)
-    logging.info("Starting Speedtest-Exporter on http://localhost:" +
-                 str(PORT))
-    serve(app, host='0.0.0.0', port=PORT)
+    def describe(self):
+        yield metrics.download_speed()
+        yield metrics.jitter()
+        yield metrics.ping()
+        yield metrics.up()
+        yield metrics.upload_speed()
+
+    def collect(self):
+        result = None
+        cached = self._speedtest.get(self._server_id, self._timeout)
+
+        if not cached:
+            result = self._speedtest(self._server_id, self._timeout)
+
+        if result is None and cached is not None:
+            result = cached.value
+
+        download = metrics.download_speed()
+        jitter = metrics.jitter()
+        ping = metrics.ping()
+        up = metrics.up()
+        upload = metrics.upload_speed()
+
+        emit = [
+            download,
+            jitter,
+            ping,
+            up,
+            upload,
+        ]
+
+        if result is not None:
+            labels = (result.result.id,)
+
+            download.add_metric(labels, result.download.bps())
+            jitter.add_metric(labels, result.ping.jitter)
+            ping.add_metric(labels, result.ping.latency)
+            upload.add_metric(labels, result.upload.bps())
+
+        up.add_metric((), 1 if result is not None else 0)
+
+        for metric in emit:
+            yield metric

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -1,12 +1,15 @@
-import subprocess
+#!python
+
+import datetime
+import logging
 import json
 import os
-import logging
-import datetime
-from prometheus_client import make_wsgi_app, Gauge
+import shutil
+import subprocess
+
 from flask import Flask
+from prometheus_client import make_wsgi_app, Gauge
 from waitress import serve
-from shutil import which
 
 app = Flask("Speedtest-Exporter")  # Create flask app
 
@@ -128,7 +131,7 @@ def mainPage():
 
 
 def checkForBinary():
-    if which("speedtest") is None:
+    if shutil.which("speedtest") is None:
         logging.error("Speedtest CLI binary not found. Please install it by" +
                       " going to the official website.\n" +
                       "https://www.speedtest.net/apps/cli")

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,77 @@
+#!python
+
+import logging
+import os
+import shutil
+import subprocess
+
+from flask import Flask
+import prometheus_client as prometheus
+from waitress import serve
+from werkzeug.middleware import dispatcher
+
+import exporter
+
+# Setup logging values
+format_string = 'level=%(levelname)s datetime=%(asctime)s %(message)s'
+logging.basicConfig(encoding='utf-8',
+                    level=logging.DEBUG,
+                    format=format_string)
+
+# Disable Waitress Logs
+log = logging.getLogger('waitress')
+# log.disabled = True
+
+
+app = Flask("Speedtest-Exporter")  # Create flask app
+app.wsgi_app = dispatcher.DispatcherMiddleware(
+    app.wsgi_app,
+    {
+        '/metrics': prometheus.make_wsgi_app(),
+    },
+)
+
+
+EXPORTER = exporter.SpeedtestExporter(
+    cache_seconds=int(os.environ.get('SPEEDTEST_CACHE_FOR', 0)),
+    server_id=os.environ.get('SPEEDTEST_SERVER'),
+    timeout=int(os.environ.get('SPEEDTEST_TIMEOUT', 90)),
+)
+
+
+prometheus.REGISTRY.register(EXPORTER)
+
+
+@app.route("/")
+def mainPage():
+    return ("<h1>Welcome to Speedtest-Exporter.</h1>" +
+            "Click <a href='/metrics'>here</a> to see metrics.\n")
+
+
+@app.route("/clear-cache", methods=['POST'])
+def clear_cache():
+    EXPORTER.clear()
+    return "OK\n"
+
+
+def checkForBinary():
+    if shutil.which("speedtest") is None:
+        logging.error("Speedtest CLI binary not found. Please install it by" +
+                      " going to the official website.\n" +
+                      "https://www.speedtest.net/apps/cli")
+        exit(1)
+    speedtestVersionDialog = (subprocess.run(['speedtest', '--version'],
+                              capture_output=True, text=True))
+    if "Speedtest by Ookla" not in speedtestVersionDialog.stdout:
+        logging.error("Speedtest CLI that is installed is not the official" +
+                      " one. Please install it by going to the official" +
+                      " website.\nhttps://www.speedtest.net/apps/cli")
+        exit(1)
+
+
+if __name__ == '__main__':
+    checkForBinary()
+    PORT = os.getenv('SPEEDTEST_PORT', 9798)
+    logging.info("Starting Speedtest-Exporter on http://localhost:" +
+                 str(PORT))
+    serve(app, host='0.0.0.0', port=PORT)

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,42 @@
+#
+
+from prometheus_client import core
+
+
+def download_speed() -> core.GaugeMetricFamily:
+    return core.GaugeMetricFamily(
+        'speedtest_download_bits_per_second',
+        'current download Speed in bit/s',
+        labels=('result_uuid',),
+    )
+
+
+def jitter() -> core.GaugeMetricFamily:
+    return core.GaugeMetricFamily(
+        'speedtest_jitter_latency_milliseconds',
+        'current jitter in ms',
+        labels=('result_uuid',),
+    )
+
+
+def ping() -> core.GaugeMetricFamily:
+    return core.GaugeMetricFamily(
+        'speedtest_ping_latency_milliseconds',
+        'current ping in ms',
+        labels=('result_uuid',),
+    )
+
+
+def up() -> core.GaugeMetricFamily:
+    return core.GaugeMetricFamily(
+        'speedtest_up',
+        '1 if the scrape worked, 0 otherwise',
+    )
+
+
+def upload_speed() -> core.GaugeMetricFamily:
+    return core.GaugeMetricFamily(
+        'speedtest_upload_bits_per_second',
+        'current upload Speed in bit/s',
+        labels=('result_uuid',),
+    )


### PR DESCRIPTION
Rewrite the collection to use a custom collector. The result UUID is added to the metric as a label, and is optionally cached for `SPEEDTEST_CACHE_FOR` seconds.

This attempts to be largely backwards compatible, the only exception is the removal of the `speedtest_server_id` metric, this could be replaced by a label eventually.

Fixes: #144