### PR TITLE
feat: ability to delay the speedtest (via env var SPEEDTEST_DELAY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ official CLI from **Ookla**
 
 You can get all the documentation [here](https://docs.miguelndecarvalho.pt/projects/speedtest-exporter/)
 
+## Environment variables
+
+| Environment Var     | Default | Description                                                                                                                     |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| SPEEDTEST_CACHE_FOR | 0       | Cache results for _x_ seconds                                                                                                   |
+| SPEEDTEST_SERVER    | NA      | Speedtest server to use, if left unset Speedtest will choose one                                                                |
+| SPEEDTEST_TIMEOUT   | 90      | How long to let the speed test run for before timeing out                                                                       |
+| SPEEDTEST_DELAY     | 0       | Delay the starting of the Speedtest <br/>(useful if you are running multiple Speedtest exporters e.g. testing a VPN connection) |
+
 ## Thanks to
 
 - [Nils Müller](https://github.com/tyriis)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -3,6 +3,7 @@ import json
 import os
 import logging
 import datetime
+import time
 from prometheus_client import make_wsgi_app, Gauge
 from flask import Flask
 from waitress import serve
@@ -36,6 +37,8 @@ up = Gauge('speedtest_up', 'Speedtest status whether the scrape worked')
 cache_seconds = int(os.environ.get('SPEEDTEST_CACHE_FOR', 0))
 cache_until = datetime.datetime.fromtimestamp(0)
 
+# delay before running speedtest
+delay = int(os.environ.get('SPEEDTEST_DELAY', 0))
 
 def bytes_to_bits(bytes_per_sec):
     return bytes_per_sec * 8
@@ -100,7 +103,9 @@ def runTest():
 
 @app.route("/metrics")
 def updateResults():
-    global cache_until
+    global cache_until, delay
+
+    time.sleep(delay)
 
     if datetime.datetime.now() > cache_until:
         r_server, r_jitter, r_ping, r_download, r_upload, r_status = runTest()


### PR DESCRIPTION
Added the env var `SPEEDTEST_DELAY` to delay the running of the speedtest.

### What does this fix?
I've been trying to run multiple instances of this speediest export as I currently have multiple internet connections (VPN's, etc.).

Prometheus doesn't have a way to stagger the scapes, I did try and use a different internals, but this was difficult to scale to 3 speedtest exporters.

Adding a delay means I can run multiple exporters with a 15 second gap between each at regular interval (every 30m)
