### PR TITLE
added server_id label to metrics

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -21,16 +21,23 @@ log = logging.getLogger('waitress')
 log.disabled = True
 
 # Create Metrics
-server = Gauge('speedtest_server_id', 'Speedtest server ID used to test')
+server = Gauge('speedtest_server_id',
+               'Speedtest server ID used to test')
 jitter = Gauge('speedtest_jitter_latency_milliseconds',
-               'Speedtest current Jitter in ms')
+               'Speedtest current Jitter in ms',
+               ['server_id'])
 ping = Gauge('speedtest_ping_latency_milliseconds',
-             'Speedtest current Ping in ms')
+             'Speedtest current Ping in ms',
+             ['server_id'])
 download_speed = Gauge('speedtest_download_bits_per_second',
-                       'Speedtest current Download Speed in bit/s')
+                       'Speedtest current Download Speed in bit/s',
+                       ['server_id'])
 upload_speed = Gauge('speedtest_upload_bits_per_second',
-                     'Speedtest current Upload speed in bits/s')
-up = Gauge('speedtest_up', 'Speedtest status whether the scrape worked')
+                     'Speedtest current Upload speed in bits/s',
+                     ['server_id'])
+up = Gauge('speedtest_up',
+           'Speedtest status whether the scrape worked',
+           ['server_id'])
 
 # Cache metrics for how long (seconds)?
 cache_seconds = int(os.environ.get('SPEEDTEST_CACHE_FOR', 0))
@@ -105,11 +112,11 @@ def updateResults():
     if datetime.datetime.now() > cache_until:
         r_server, r_jitter, r_ping, r_download, r_upload, r_status = runTest()
         server.set(r_server)
-        jitter.set(r_jitter)
-        ping.set(r_ping)
-        download_speed.set(r_download)
-        upload_speed.set(r_upload)
-        up.set(r_status)
+        jitter.labels(r_server).set(r_jitter)
+        ping.labels(r_server).set(r_ping)
+        download_speed.labels(r_server).set(r_download)
+        upload_speed.labels(r_server).set(r_upload)
+        up.labels(r_server).set(r_status)
         logging.info("Server=" + str(r_server) + " Jitter=" + str(r_jitter) +
                      "ms" + " Ping=" + str(r_ping) + "ms" + " Download=" +
                      bits_to_megabits(r_download) + " Upload=" +


### PR DESCRIPTION
Added server_id as label to each measurable metric. It's pretty handy to be able to track server_id for each metric (when auto selection is enabled, You can't be sure to get the same server). This also allows for easy tests against multiple servers.