### PR TITLE
fix: healthcheck issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ USER speedtest
 
 CMD ["python", "-u", "exporter.py"]
 
-HEALTHCHECK --timeout=10s CMD wget --no-verbose --tries=1 --spider http://localhost:${SPEEDTEST_PORT:=9798}/
+HEALTHCHECK --timeout=10s CMD wget --no-verbose --tries=1 --spider http://0.0.0.0:${SPEEDTEST_PORT:=9798}/


### PR DESCRIPTION
Fix issues: #216 and possibly #212

Use `0.0.0.0` instead of `localhost` to fix healthcheck issues in container.
